### PR TITLE
Only attempt to dispose of changeDetector subscriptions if they exist

### DIFF
--- a/src/change-detector.ts
+++ b/src/change-detector.ts
@@ -43,9 +43,11 @@ export default class ChangeDetector {
   }
   removeReactionList(vm: VueClass) {
     const reactivePropertyListKey = this._getReactionListKey(vm)
-
-    this.changeDetector[reactivePropertyListKey].forEach(dispose => dispose())
-    delete this.changeDetector[reactivePropertyListKey]
+    // only try to dispose of changeDetector subscriptions if they exist!
+    if (!!this.changeDetector[reactivePropertyListKey]) {
+      this.changeDetector[reactivePropertyListKey].forEach(dispose => dispose())
+      delete this.changeDetector[reactivePropertyListKey]
+    }
   }
 
   _getReactionListKey(vm: VueClass): string {


### PR DESCRIPTION
Had a few issues with components where `beforeDestroy` was called multiple times. It seems like the `movue` mixin was being added two times, so this makes sure that we don't try to access a changeDetector that has already been removed/disposed of.